### PR TITLE
Update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ var mergeTrees = require('broccoli-merge-trees');
 // the first paramter, and specify source and
 // destination directories.
 // Custom YUIdoc options is passed as yuidoc.
-var yuidocTree = yuidocCompiler('app', {
-	srcDir: '/',
+var yuidocTree = new yuidocCompiler(['app'], {
 	destDir: 'docs',
 	yuidoc: {
 		// .. yuidoc option overrides

--- a/index.js
+++ b/index.js
@@ -1,14 +1,13 @@
 'use strict';
 
-var merge   = require('merge');
-var yuidoc  = require('yuidocjs');
-var rsvp    = require('rsvp');
-var fs      = require('fs');
-var path    = require('path');
+var merge         = require('merge');
+var yuidoc        = require('yuidocjs');
+var rsvp          = require('rsvp');
+var fs            = require('fs');
+var path          = require('path');
 var CachingWriter = require('broccoli-caching-writer');
 
 var defaultOpts = {
-  srcDir: 'app',
   destDir: 'docs',
   yuidoc: {
     linkNatives: true,
@@ -18,18 +17,29 @@ var defaultOpts = {
   }
 };
 
+var BroccoliYuidoc = function BroccoliYuidoc(inputNodes, options) {
+  if (!(this instanceof BroccoliYuidoc)) {
+    return new BroccoliYuidoc(inputNodes, options);
+  }
 
-var BroccoliYuidoc = CachingWriter.extend({
-  init: function(inputTree) {
-    this.inputTree = inputTree;
-    this.yuidoc = merge(defaultOpts, this.yuidoc);
-  },
+  options = options || {};
+  CachingWriter.call(this, inputNodes, {
+    annotation: options.annotation
+  });
+  this.inputNodes = inputNodes;
+  this.options    = merge(defaultOpts, options);
+};
 
-  updateCache: function(srcPaths, destDir) {
-    var options = this.yuidoc;
+BroccoliYuidoc.prototype = Object.create(CachingWriter.prototype);
+BroccoliYuidoc.prototype.constructor = BroccoliYuidoc;
+BroccoliYuidoc.prototype.description = 'yuidoc';
+BroccoliYuidoc.prototype.write = function(readTree, destDir) {
+  var self = this;
+  return readTree(this.inputNodes).then(function() {
+    var options = self.options;
 
     options.paths = options.paths || srcPaths;
-    options.outdir = [destDir, this.destDir].join('/');
+    options.outdir = [destDir, self.destDir].join('/');
 
      try {
        var json = (new yuidoc.YUIDoc(options)).run();
@@ -45,12 +55,11 @@ var BroccoliYuidoc = CachingWriter.extend({
     }
 
     var builder = new yuidoc.DocBuilder(options, json);
-    var self = this;
 
     return new rsvp.Promise(function(resolve) {
       builder.compile(function() { resolve(); });
     });
-  }
-});
+  });
+};
 
 module.exports = BroccoliYuidoc;

--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
     "url": "https://github.com/uitgewis/broccoli-yuidoc"
   },
   "dependencies": {
-    "yuidocjs": "~0.5.0",
-    "broccoli-merge-trees": "~0.2.1",
+    "yuidocjs": "~0.9.0",
+    "broccoli-merge-trees": "~0.2.3",
     "merge": "~1.2.0",
-    "rsvp": "~3.0.14",
-    "broccoli-caching-writer": "~0.5.1"
+    "rsvp": "~3.1.0",
+    "broccoli-caching-writer": "~2.0.1"
   },
   "engines": {
     "node": "*"


### PR DESCRIPTION
This updates all the dependencies to the latest versions (especially broccoli-caching-writer and yuidocjs itself) and updates the implementation to work with the new broccoli-caching-writer API.

Also fixes the README to correctly state that `new yuidoc` is actually necessary instead of just `yuidoc`.